### PR TITLE
Return better errors to help downstream clients

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,16 @@ services:
       - POSTGRES_USER=platform
       - POSTGRES_PASSWORD=QdYx3D5y
   test: &test-base
-    image: node:carbon
-    command: bash -c "sh ./wait-for-db.sh && yarn test"
+    build:
+      context: .
+    command: sh -c "sh ./wait-for-db.sh && yarn test"
     working_dir: /usr/src/app
     depends_on:
       - db
     volumes:
       - .:/usr/src/app:Z
+    environment:
+      - NODE_ENV=test
   watch_test:
     <<: *test-base
     command: ./node_modules/.bin/nodemon --exec yarn test

--- a/memberships/errors.js
+++ b/memberships/errors.js
@@ -9,7 +9,7 @@ class MembershipExists extends Error {
   constructor() {
     super();
     this.message = 'Membership already has this role';
-    this.status = 400;
+    this.status = 409;
   }
 }
 module.exports = {

--- a/test/integration/club.createMembership.spec.js
+++ b/test/integration/club.createMembership.spec.js
@@ -45,7 +45,7 @@ describe('integration:club:createMembership', () => {
         userType: 'mentor',
       })
       .set('Accept', 'application/json')
-      .expect(400);
+      .expect(409);
   });
   it('should return 404 on non-existing club', async () => {
     await request(app)

--- a/test/integration/lead.list.spec.js
+++ b/test/integration/lead.list.spec.js
@@ -28,11 +28,11 @@ describe('integration:leads:list', () => {
     expect(res.body.total).to.equal(0);
   });
 
-  it('should return 400 on wrong params', async () => {
+  it('should return 422 on wrong params', async () => {
     await request(app)
       .get('/leads?userId=123')
       .set('Accept', 'application/json')
-      .expect(400);
+      .expect(422);
   });
 });
 

--- a/test/integration/membership.update.spec.js
+++ b/test/integration/membership.update.spec.js
@@ -21,14 +21,14 @@ describe('integration:membership:update', () => {
     expect(res.body.userTypes).to.eql(['parent-guardian', 'mentor']);
     expect(res.body.userPermissions).to.eql([{ title: 'Ticketing Admin', name: 'ticketing-admin' }]);
   });
-  it('should return 400 when the role already exists', async () => {
+  it('should return 409 when the role already exists', async () => {
     await request(app)
       .post('/memberships/463e716d-e2c6-42f6-9809-dc6236f0e480/roles')
       .send({
         userType: 'mentor',
       })
       .set('Accept', 'application/json')
-      .expect(400);
+      .expect(409);
   });
   it('should not have duplicate permissions', async () => {
     const res = await request(app)

--- a/test/unit/memberships/controller/create.spec.js
+++ b/test/unit/memberships/controller/create.spec.js
@@ -42,7 +42,7 @@ describe('memberships/controller:create', () => {
         await memberController.create('u1', 'd1', 'champion');
       } catch (e) {
         expect(constr).to.not.have.been.called;
-        expect(e.status).to.equal(400);
+        expect(e.status).to.equal(409);
       }
     });
   });

--- a/test/unit/memberships/controller/createRole.spec.js
+++ b/test/unit/memberships/controller/createRole.spec.js
@@ -42,7 +42,7 @@ describe('memberships/controller:update', () => {
         expect(queryBuilder.findOne).to.have.been.calledOnce.and
           .calledWith({ id: 'u1' });
         expect(queryBuilder.update).to.not.have.been.called;
-        expect(e.status).to.equal(400);
+        expect(e.status).to.equal(409);
       }
     });
   });

--- a/util/ValidationHelper.js
+++ b/util/ValidationHelper.js
@@ -6,7 +6,7 @@ class ValidationHelper {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
       logger.error(errors.mapped());
-      return res.status(400).json({ errors: errors.mapped() });
+      return res.status(422).json({ errors: errors.mapped() });
     }
     return next();
   }

--- a/wait-for-db.sh
+++ b/wait-for-db.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -e
 
-apt-get update
-apt-get install -y postgresql-client
 pg_isready -h db
 while ! pg_isready -h db > /dev/null 2> /dev/null; do
   echo "Connecting to db Failed"

--- a/wait-for-db.sh
+++ b/wait-for-db.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 
-pg_isready -h db
 while ! pg_isready -h db > /dev/null 2> /dev/null; do
-  echo "Connecting to db Failed"
+  echo "Waiting for db to be ready"
   sleep 1
 done
+
 echo "Connected to db"
 exit 0


### PR DESCRIPTION
* Return 409 Conflict if the role already exists
* Return 422 Unprocessable if there is a validation error.

This also changes the way tests are run in CI.  It now uses the Dockerfile to build the image to test.  This change was made because the "stretch" release of Debian (which the `node:carbon` image uses) is long dead, and the package archives have now been removed.
